### PR TITLE
Fixed breadcrumb list when using nested routes with IndexRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ npm i -S react-bootstrap-breadcrumbs
 
 ## Example
 ```
-<Route name='items' path='/items' handler={ItemsPage}>
-  <Route name='item' path=':itemId' handler={ItemPage} />
+<Route name='items' path='/items'>
+  <IndexRoute component={ItemsPage} />
+  <Route name='item' path=':itemId' component={ItemPage} />
 </Route>
 
 ...

--- a/src/Breadcrumbs.js
+++ b/src/Breadcrumbs.js
@@ -31,6 +31,8 @@ function getBreadcrumbs(routes, routerParams, getTitle) {
       } else {
         path += '/' + route.path;
       }
+    } else {
+      return false;
     }
 
     return {


### PR DESCRIPTION
This fix removed a double entry in the breadcrumb for the IndexRoute.
